### PR TITLE
Non-destructive `@keyframes` rule transformation.

### DIFF
--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -147,9 +147,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // transforms a css rule to a scoped rule.
       _transformRule: function(rule, transformer, scope, hostScope) {
+        // The selector can only be transformed if it is a selector; a
+        // selector-like ruleset that appears within a `@keyframes` rule is
+        // actually a keyframe, not a selector:
+        var selectorCanTransform =
+          !rule.parent ||
+          rule.parent.ruleType !== Polymer.StyleUtil.ruleTypes.KEYFRAMES_RULE;
         var p$ = rule.selector.split(COMPLEX_SELECTOR_SEP);
-        for (var i=0, l=p$.length, p; (i<l) && (p=p$[i]); i++) {
-          p$[i] = transformer.call(this, p, scope, hostScope);
+        if (selectorCanTransform) {
+          for (var i=0, l=p$.length, p; (i<l) && (p=p$[i]); i++) {
+            p$[i] = transformer.call(this, p, scope, hostScope);
+          }
         }
         // NOTE: save transformedSelector for subsequent matching of elements
         // against selectors (e.g. when calculating style properties)

--- a/src/lib/style-util.html
+++ b/src/lib/style-util.html
@@ -51,8 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var skipRules = false;
         if (node.type === this.ruleTypes.STYLE_RULE) {
           callback(node);
-        } else if (node.type === this.ruleTypes.KEYFRAMES_RULE ||
-            node.type === this.ruleTypes.MIXIN_RULE) {
+        } else if (node.type === this.ruleTypes.MIXIN_RULE) {
           skipRules = true;
         }
         var r$ = node.rules;


### PR DESCRIPTION
Previously, the transformer did not disambiguate selectors in `@media`
blocks and keyframes in `@keyframes` blocks. Now, the transformer can
safely transform `@keyframes` blocks. Before a selector is transformed,
if the selector has a parent, it is checked. If the checked parent is a
`@keyframes` rule, the selector transformation is skipped.polymer